### PR TITLE
RHCLOUD-46708 - Implement principal from RH identity helpers

### DIFF
--- a/examples/console_principal.rb
+++ b/examples/console_principal.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'kessel-sdk'
+require 'kessel/console'
+require 'json'
+require 'base64'
+
+include Kessel::Console
+
+# --- From a parsed User identity hash ---
+user_identity = {
+  'type' => 'User',
+  'org_id' => '12345',
+  'user' => { 'user_id' => '7393748', 'username' => 'jdoe' }
+}
+
+subject = principal_from_rh_identity(user_identity)
+puts "User principal:            #{subject.resource.resource_id}"
+
+# --- From a parsed ServiceAccount identity hash ---
+sa_identity = {
+  'type' => 'ServiceAccount',
+  'org_id' => '456',
+  'service_account' => {
+    'user_id' => '12345',
+    'client_id' => 'b69eaf9e-e6a6-4f9e-805e-02987daddfbd',
+    'username' => 'service-account-b69eaf9e'
+  }
+}
+
+subject = principal_from_rh_identity(sa_identity)
+puts "ServiceAccount principal:  #{subject.resource.resource_id}"
+
+# --- From a raw base64-encoded x-rh-identity header ---
+header_payload = {
+  'identity' => {
+    'type' => 'User',
+    'org_id' => '12345',
+    'user' => { 'user_id' => '7393748', 'username' => 'jdoe' }
+  }
+}
+
+header = Base64.strict_encode64(JSON.generate(header_payload))
+subject = principal_from_rh_identity_header(header)
+puts "From header principal:     #{subject.resource.resource_id}"

--- a/lib/kessel/console.rb
+++ b/lib/kessel/console.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'base64'
+require_relative 'rbac/v2_helpers'
+
+module Kessel
+  module Console
+    include Kessel::RBAC::V2
+    extend  Kessel::RBAC::V2
+
+    DEFAULT_DOMAIN = 'redhat'
+
+    IDENTITY_TYPE_FIELDS = {
+      'User' => 'user',
+      'ServiceAccount' => 'service_account'
+    }.freeze
+
+    module_function
+
+    def principal_from_rh_identity(identity, domain: DEFAULT_DOMAIN)
+      user_id = extract_user_id(identity)
+      principal_subject(user_id, domain)
+    end
+
+    def principal_from_rh_identity_header(header, domain: DEFAULT_DOMAIN)
+      decoded = JSON.parse(Base64.decode64(header))
+    rescue StandardError => e
+      raise ArgumentError, "Failed to decode identity header: #{e.message}"
+    else
+      raise ArgumentError, 'Identity header did not decode to a JSON object' unless decoded.is_a?(Hash)
+
+      identity = decoded['identity']
+      raise ArgumentError, "Identity header is missing the 'identity' envelope key" if identity.nil?
+
+      principal_from_rh_identity(identity, domain: domain)
+    end
+
+    def extract_user_id(identity)
+      raise ArgumentError, 'identity must be a Hash' unless identity.is_a?(Hash)
+
+      identity_type = identity['type']
+      field = identity_field_for(identity_type)
+      details = identity_details_for(identity, field, identity_type)
+      resolve_user_id(details, identity_type)
+    end
+
+    def identity_field_for(identity_type)
+      IDENTITY_TYPE_FIELDS.fetch(identity_type) do
+        supported = IDENTITY_TYPE_FIELDS.keys.sort.join(', ')
+        raise ArgumentError, "Unsupported identity type: #{identity_type.inspect} (supported: #{supported})"
+      end
+    end
+
+    def identity_details_for(identity, field, identity_type)
+      details = identity[field]
+      unless details.is_a?(Hash)
+        raise ArgumentError, "Identity type #{identity_type.inspect} is missing the '#{field}' field"
+      end
+
+      details
+    end
+
+    def resolve_user_id(details, identity_type)
+      user_id = details['user_id'].to_s
+      raise ArgumentError, "Unable to resolve user ID from #{identity_type} identity (tried: user_id)" if user_id.empty?
+
+      user_id
+    end
+
+    private_class_method :extract_user_id, :identity_field_for, :identity_details_for, :resolve_user_id
+  end
+end

--- a/lib/kessel/console.rb
+++ b/lib/kessel/console.rb
@@ -7,7 +7,7 @@ require_relative 'rbac/v2_helpers'
 module Kessel
   module Console
     include Kessel::RBAC::V2
-    extend  Kessel::RBAC::V2
+    extend self
 
     DEFAULT_DOMAIN = 'redhat'
 
@@ -15,8 +15,6 @@ module Kessel
       'User' => 'user',
       'ServiceAccount' => 'service_account'
     }.freeze
-
-    module_function
 
     def principal_from_rh_identity(identity, domain: DEFAULT_DOMAIN)
       user_id = extract_user_id(identity)
@@ -35,6 +33,8 @@ module Kessel
 
       principal_from_rh_identity(identity, domain: domain)
     end
+
+    private
 
     def extract_user_id(identity)
       raise ArgumentError, 'identity must be a Hash' unless identity.is_a?(Hash)
@@ -67,7 +67,5 @@ module Kessel
 
       user_id
     end
-
-    private_class_method :extract_user_id, :identity_field_for, :identity_details_for, :resolve_user_id
   end
 end

--- a/spec/kessel/console_spec.rb
+++ b/spec/kessel/console_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'base64'
+require 'json'
+require 'kessel/console'
+
+def encode_identity_header(payload)
+  Base64.strict_encode64(JSON.generate(payload))
+end
+
+RSpec.describe Kessel::Console do
+  describe '.principal_from_rh_identity' do
+    it 'resolves User identity' do
+      identity = {
+        'type' => 'User',
+        'org_id' => '1979710',
+        'user' => { 'user_id' => '7393748', 'username' => 'foobar' }
+      }
+      ref = described_class.principal_from_rh_identity(identity)
+      expect(ref.resource.resource_type).to eq('principal')
+      expect(ref.resource.resource_id).to eq('redhat/7393748')
+      expect(ref.resource.reporter.type).to eq('rbac')
+    end
+
+    it 'resolves ServiceAccount identity' do
+      identity = {
+        'type' => 'ServiceAccount',
+        'org_id' => '456',
+        'service_account' => { 'user_id' => 'sa-456', 'client_id' => 'b69eaf9e', 'username' => 'svc-b69eaf9e' }
+      }
+      ref = described_class.principal_from_rh_identity(identity)
+      expect(ref.resource.resource_id).to eq('redhat/sa-456')
+    end
+
+    it 'uses custom domain' do
+      identity = { 'type' => 'User', 'user' => { 'user_id' => '42' } }
+      ref = described_class.principal_from_rh_identity(identity, domain: 'custom')
+      expect(ref.resource.resource_id).to eq('custom/42')
+    end
+
+    it 'raises for unsupported identity type' do
+      identity = { 'type' => 'System', 'system' => { 'cn' => 'abc' } }
+      expect { described_class.principal_from_rh_identity(identity) }
+        .to raise_error(ArgumentError, /Unsupported identity type/)
+    end
+
+    it 'raises for missing type field' do
+      identity = { 'org_id' => '123' }
+      expect { described_class.principal_from_rh_identity(identity) }
+        .to raise_error(ArgumentError, /Unsupported identity type/)
+    end
+
+    it 'raises for missing user details' do
+      identity = { 'type' => 'User' }
+      expect { described_class.principal_from_rh_identity(identity) }
+        .to raise_error(ArgumentError, /missing the 'user' field/)
+    end
+
+    it 'raises for missing service_account details' do
+      identity = { 'type' => 'ServiceAccount' }
+      expect { described_class.principal_from_rh_identity(identity) }
+        .to raise_error(ArgumentError, /missing the 'service_account' field/)
+    end
+
+    it 'raises for user details not a Hash' do
+      identity = { 'type' => 'User', 'user' => 'not-a-hash' }
+      expect { described_class.principal_from_rh_identity(identity) }
+        .to raise_error(ArgumentError, /missing the 'user' field/)
+    end
+
+    it 'raises for missing user_id' do
+      identity = { 'type' => 'User', 'user' => { 'username' => 'foobar' } }
+      expect { described_class.principal_from_rh_identity(identity) }
+        .to raise_error(ArgumentError, /Unable to resolve user ID/)
+    end
+
+    it 'raises for empty user_id' do
+      identity = { 'type' => 'User', 'user' => { 'user_id' => '' } }
+      expect { described_class.principal_from_rh_identity(identity) }
+        .to raise_error(ArgumentError, /Unable to resolve user ID/)
+    end
+
+    it 'raises for nil identity' do
+      expect { described_class.principal_from_rh_identity(nil) }
+        .to raise_error(ArgumentError, /identity must be a Hash/)
+    end
+
+    it 'raises for string identity' do
+      expect { described_class.principal_from_rh_identity('not-a-hash') }
+        .to raise_error(ArgumentError, /identity must be a Hash/)
+    end
+
+    %w[System X509 Associate].each do |identity_type|
+      it "raises for unsupported type #{identity_type}" do
+        identity = { 'type' => identity_type }
+        expect { described_class.principal_from_rh_identity(identity) }
+          .to raise_error(ArgumentError, /Unsupported identity type/)
+      end
+    end
+  end
+
+  describe '.principal_from_rh_identity_header' do
+    it 'decodes valid User header' do
+      header = encode_identity_header(
+        'identity' => {
+          'type' => 'User',
+          'org_id' => '1979710',
+          'user' => { 'user_id' => '7393748', 'username' => 'foobar' }
+        }
+      )
+      ref = described_class.principal_from_rh_identity_header(header)
+      expect(ref.resource.resource_id).to eq('redhat/7393748')
+      expect(ref.resource.resource_type).to eq('principal')
+    end
+
+    it 'decodes valid ServiceAccount header' do
+      header = encode_identity_header(
+        'identity' => {
+          'type' => 'ServiceAccount',
+          'org_id' => '456',
+          'service_account' => { 'user_id' => 'sa-789', 'client_id' => 'b69eaf9e' }
+        }
+      )
+      ref = described_class.principal_from_rh_identity_header(header)
+      expect(ref.resource.resource_id).to eq('redhat/sa-789')
+    end
+
+    it 'uses custom domain' do
+      header = encode_identity_header(
+        'identity' => { 'type' => 'User', 'user' => { 'user_id' => '1' } }
+      )
+      ref = described_class.principal_from_rh_identity_header(header, domain: 'acme')
+      expect(ref.resource.resource_id).to eq('acme/1')
+    end
+
+    it 'raises for missing identity envelope' do
+      header = encode_identity_header('type' => 'User', 'user' => { 'user_id' => '42' })
+      expect { described_class.principal_from_rh_identity_header(header) }
+        .to raise_error(ArgumentError, /missing the 'identity' envelope key/)
+    end
+
+    it 'raises for invalid JSON' do
+      header = Base64.strict_encode64('this is not json')
+      expect { described_class.principal_from_rh_identity_header(header) }
+        .to raise_error(ArgumentError, /Failed to decode identity header/)
+    end
+
+    it 'raises for non-object JSON' do
+      header = Base64.strict_encode64('"just a string"')
+      expect { described_class.principal_from_rh_identity_header(header) }
+        .to raise_error(ArgumentError, /did not decode to a JSON object/)
+    end
+
+    it 'raises for unsupported type in header' do
+      header = encode_identity_header(
+        'identity' => { 'type' => 'System', 'system' => { 'cn' => 'abc', 'cert_type' => 'system' } }
+      )
+      expect { described_class.principal_from_rh_identity_header(header) }
+        .to raise_error(ArgumentError, /Unsupported identity type/)
+    end
+
+    it 'raises for missing user_id in header' do
+      header = encode_identity_header(
+        'identity' => {
+          'type' => 'User',
+          'org_id' => '1979710',
+          'user' => { 'username' => 'foobar' }
+        }
+      )
+      expect { described_class.principal_from_rh_identity_header(header) }
+        .to raise_error(ArgumentError, /Unable to resolve user ID/)
+    end
+
+    it 'decodes realistic User header' do
+      header = encode_identity_header(
+        'identity' => {
+          'account_number' => '540155',
+          'org_id' => '1979710',
+          'user' => {
+            'username' => 'rhn-support-foobar',
+            'is_internal' => true,
+            'is_org_admin' => true,
+            'first_name' => 'foo',
+            'last_name' => 'bar',
+            'is_active' => true,
+            'user_id' => '7393748',
+            'email' => 'example@redhat.com'
+          },
+          'type' => 'User'
+        }
+      )
+      ref = described_class.principal_from_rh_identity_header(header)
+      expect(ref.resource.resource_id).to eq('redhat/7393748')
+      expect(ref.resource.resource_type).to eq('principal')
+      expect(ref.resource.reporter.type).to eq('rbac')
+    end
+
+    it 'decodes realistic ServiceAccount header' do
+      header = encode_identity_header(
+        'identity' => {
+          'org_id' => '456',
+          'type' => 'ServiceAccount',
+          'service_account' => {
+            'user_id' => 'sa-b69eaf9e',
+            'client_id' => 'b69eaf9e-e6a6-4f9e-805e-02987daddfbd',
+            'username' => 'service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd'
+          }
+        }
+      )
+      ref = described_class.principal_from_rh_identity_header(header)
+      expect(ref.resource.resource_id).to eq('redhat/sa-b69eaf9e')
+    end
+  end
+end


### PR DESCRIPTION
Adds `principal_from_rh_identity()` and `principal_from_rh_identity_header()` to new `console` pkg, enabling consumers to build principal SubjectReferences directly from platform identity dicts or raw x-rh-identity headers.

https://redhat.atlassian.net/browse/RHCLOUD-46708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert Red Hat identity objects and x-rh-identity encoded headers into RBAC principals with a configurable domain.

* **Examples**
  * Added a console example demonstrating principal conversion for User and ServiceAccount identities and printing resulting resource IDs.

* **Tests**
  * Added comprehensive tests covering successful conversions, domain override, and extensive error handling for invalid/ malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->