### PR TITLE
Release v1.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kessel-sdk (1.8.0)
+    kessel-sdk (1.9.0)
       grpc (>= 1.73.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ The `examples/` directory contains working examples. Set up environment variable
 | `fetch_workspaces.rb` | Fetching workspaces via RBAC HTTP API |
 | `list_workspaces.rb` | Listing workspaces with auto-pagination |
 | `report_resource.rb` | Reporting resource state |
+| `console_principal.rb` | Building principals from `x-rh-identity` headers |
 | `streamed_list_objects.rb` | Streaming resource lists |
 
 Run examples:

--- a/lib/kessel/version.rb
+++ b/lib/kessel/version.rb
@@ -2,6 +2,6 @@
 
 module Kessel
   module Inventory
-    VERSION = '1.8.0'
+    VERSION = '1.9.0'
   end
 end


### PR DESCRIPTION
## Summary

- Bump version to 1.9.0
- Add `console_principal.rb` example to README

### New in v1.9.0 (since v1.8.0)

- **`Kessel::Console` module** -- `principal_from_rh_identity` and `principal_from_rh_identity_header` helpers for building principal subjects from `x-rh-identity` headers
- **`examples/console_principal.rb`** -- working example for the Console module
- AI agent readiness documentation (`AGENTS.md`, `CLAUDE.md`, `docs/`)
- README restructured and expanded

### Quality checks

- RSpec: 127 examples, 0 failures
- RuboCop: 22 files, no offenses
- bundler-audit: 1 non-blocking advisory (transitive `json` gem)
- Local gem build and install: successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended examples section with documentation for a new example script.

* **Chores**
  * Bumped version to 1.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->