### PR TITLE
RHCLOUD-47741 - Update locking mechanism for concurrent token refreshes

### DIFF
--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -6,17 +6,21 @@
 
 `OAuth2ClientCredentials` caches the access token in `@cached_token` and protects refresh with `@token_mutex`. Creating multiple instances defeats caching and causes redundant token requests.
 
-### Token refresh uses double-checked locking -- do not bypass it
+### Token refresh uses double-checked locking with a generation counter -- do not bypass it
 
-`get_token` checks `token_valid?` outside the mutex for the fast path, then re-checks inside `@token_mutex.synchronize` to prevent thundering herd. When adding new auth flows, follow this exact pattern:
+`get_token` checks `token_valid?` outside the mutex for the fast path, then uses a generation counter inside `@token_mutex.synchronize` to coalesce concurrent refresh requests (including `force_refresh: true`) into a single SSO call per refresh cycle. When adding new auth flows, follow this exact pattern:
 
 ```ruby
 return @cached_token if !force_refresh && token_valid?
+generation = @generation
 @token_mutex.synchronize do
-  return @cached_token if token_valid?
+  return @cached_token if @generation != generation && token_valid?
   @cached_token = refresh
+  @generation += 1
 end
 ```
+
+The generation counter prevents the thundering herd for `force_refresh: true` concurrent callers. Without it, each caller that enters the mutex would clear the cache and issue its own SSO request. The generation snapshot taken before acquiring the lock lets waiters detect that another thread already refreshed, so they return the fresh token without a redundant network call.
 
 ### Frozen token response objects prevent accidental mutation
 
@@ -28,7 +32,7 @@ end
 
 ### Use `force_refresh: true` sparingly
 
-`get_token(force_refresh: true)` clears the cache inside the mutex and forces a network call. Only use it after receiving an explicit 401/UNAUTHENTICATED error, never preemptively.
+`get_token(force_refresh: true)` forces a token refresh inside the mutex. Concurrent `force_refresh` callers coalesce into a single SSO request via the generation counter. Only use it after receiving an explicit 401/UNAUTHENTICATED error, never preemptively.
 
 ## gRPC Client Lifecycle
 

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -8,8 +8,8 @@
 - Avoid adding `openid_connect` as a hard runtime dependency; it should remain optional so consumers who do not need OAuth are not forced to install it.
 
 ### Token Caching and Thread Safety
-- `OAuth2ClientCredentials` uses a `Mutex` (`@token_mutex`) to synchronize token refresh across threads. Maintain this pattern -- token operations should remain thread-safe.
-- The `get_token` method uses a double-check pattern: it checks `token_valid?` before acquiring the lock, then checks again inside the synchronized block to prevent redundant refreshes.
+- `OAuth2ClientCredentials` uses a `Mutex` (`@token_mutex`) with a `@generation` counter to synchronize token refresh across threads. Maintain this pattern -- token operations should remain thread-safe.
+- The `get_token` method uses double-checked locking with a generation counter: it checks `token_valid?` before acquiring the lock, snapshots `@generation`, then inside the synchronized block checks whether `@generation` changed (indicating another thread already refreshed). This prevents both stale-token and `force_refresh` thundering herd scenarios -- concurrent callers coalesce into a single SSO request per refresh cycle.
 - Cached tokens are frozen with `.freeze` after creation in the `refresh` method. Preserve the freeze call -- it prevents accidental mutation of shared token state.
 
 ### Token Expiration Window

--- a/lib/kessel/auth.rb
+++ b/lib/kessel/auth.rb
@@ -130,6 +130,7 @@ module Kessel
         @client_secret = client_secret
         @token_endpoint = token_endpoint
         @token_mutex = Mutex.new
+        @generation = 0
       end
 
       # Gets the current access token with automatic caching and refresh.
@@ -146,13 +147,14 @@ module Kessel
       def get_token(force_refresh: false)
         return @cached_token if !force_refresh && token_valid?
 
-        @token_mutex.synchronize do
-          @cached_token = nil if force_refresh
+        generation = @generation
 
-          # Double-check: another thread might have refreshed the token
-          return @cached_token if token_valid?
+        @token_mutex.synchronize do
+          # Another thread already refreshed while we waited on the lock
+          return @cached_token if @generation != generation && token_valid?
 
           @cached_token = refresh
+          @generation += 1
 
           return @cached_token
         rescue StandardError => e

--- a/sig/kessel/auth.rbs
+++ b/sig/kessel/auth.rbs
@@ -41,6 +41,9 @@ module Kessel
 
     # OpenID Connect Client Credentials flow implementation
     class OAuth2ClientCredentials
+      @token_mutex: Mutex
+      @generation: Integer
+
       def initialize: (client_id: String, client_secret: String, token_endpoint: String) -> void
       def get_token: (?force_refresh: bool) -> RefreshTokenResponse
 

--- a/spec/kessel/auth_thundering_herd_spec.rb
+++ b/spec/kessel/auth_thundering_herd_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'OAuth2ClientCredentials thundering herd prevention' do
+  let(:client_id) { 'test-client' }
+  let(:client_secret) { 'test-secret' }
+  let(:token_endpoint) { 'https://auth.example.com/token' }
+  let(:num_threads) { 20 }
+
+  let(:counter_mutex) { Mutex.new }
+  let(:sso_call_count) { { value: 0 } }
+  let(:mock_client) { double('OpenIDConnect::Client') }
+
+  let(:oauth) do
+    Kessel::Auth::OAuth2ClientCredentials.new(
+      client_id: client_id,
+      client_secret: client_secret,
+      token_endpoint: token_endpoint
+    )
+  end
+
+  before do
+    stub_const('OpenIDConnect', Module.new)
+    stub_const('OpenIDConnect::Client', Class.new)
+    allow_any_instance_of(Kessel::Auth::OAuth2ClientCredentials).to receive(:require)
+      .with('openid_connect')
+      .and_return(true)
+
+    mu = counter_mutex
+    count = sso_call_count
+    allow(oauth).to receive(:create_oidc_client).and_return(mock_client)
+    allow(mock_client).to receive(:access_token!) do
+      mu.synchronize { count[:value] += 1 }
+      sleep 0.05
+      double('token_response', access_token: 'refreshed-token', expires_in: 3600)
+    end
+  end
+
+  def run_concurrent_get_token(oauth, num_threads, **kwargs)
+    barrier = Queue.new
+    results = Queue.new
+
+    threads = num_threads.times.map do
+      Thread.new do
+        barrier.pop
+        token = oauth.get_token(**kwargs)
+        results.push(token)
+      rescue StandardError => e
+        results.push(e)
+      end
+    end
+
+    num_threads.times { barrier.push(:go) }
+    threads.each(&:join)
+
+    num_threads.times.map { results.pop }
+  end
+
+  context 'with a stale token (inside the 300s early-refresh window)' do
+    before do
+      stale_token = Kessel::Auth::RefreshTokenResponse.new('stale-token', Time.now + 60)
+      oauth.instance_variable_set(:@cached_token, stale_token)
+    end
+
+    it 'results in exactly 1 SSO call when 20 threads refresh concurrently' do
+      tokens = run_concurrent_get_token(oauth, num_threads)
+
+      expect(sso_call_count[:value]).to eq(1)
+      tokens.each do |token|
+        expect(token).to be_a(Kessel::Auth::RefreshTokenResponse)
+        expect(token.access_token).to eq('refreshed-token')
+      end
+    end
+  end
+
+  context 'with concurrent force_refresh: true calls' do
+    before do
+      valid_token = Kessel::Auth::RefreshTokenResponse.new('valid-token', Time.now + 3600)
+      oauth.instance_variable_set(:@cached_token, valid_token)
+    end
+
+    it 'results in exactly 1 SSO call when 20 threads force-refresh concurrently' do
+      tokens = run_concurrent_get_token(oauth, num_threads, force_refresh: true)
+
+      expect(sso_call_count[:value]).to eq(1)
+      tokens.each do |token|
+        expect(token).to be_a(Kessel::Auth::RefreshTokenResponse)
+        expect(token.access_token).to eq('refreshed-token')
+      end
+    end
+  end
+
+  context 'with a cold start (no cached token)' do
+    it 'results in exactly 1 SSO call when 20 threads start concurrently' do
+      tokens = run_concurrent_get_token(oauth, num_threads)
+
+      expect(sso_call_count[:value]).to eq(1)
+      tokens.each do |token|
+        expect(token).to be_a(Kessel::Auth::RefreshTokenResponse)
+        expect(token.access_token).to eq('refreshed-token')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces a way to prevent multiple concurrent calls to SSO using a generation counter
Aligned with python SDK code paths

https://redhat.atlassian.net/browse/RHCLOUD-47741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safe token authentication to prevent concurrent refresh operations and stale token scenarios.

* **Documentation**
  * Updated performance and security guidelines with thread-safety best practices.

* **Tests**
  * Added test coverage for concurrent token refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->