### PR TITLE
RHCLOUD-48470 - Add consistency token support to list_workspaces()

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,14 +209,15 @@ client = KesselInventoryService::ClientBuilder.new('localhost:9000')
                                               .build
 
 subject = principal_subject("alice", "redhat")
+consistency = Kessel::Inventory::V1beta2::Consistency.new(minimize_latency: true)
 
 # Lazy iteration (constant memory)
-list_workspaces(client, subject, "viewer").each do |response|
+list_workspaces(client, subject, "viewer", consistency: consistency).each do |response|
   puts response.object.resource_id
 end
 
 # Materialise into an Array
-all_workspaces = list_workspaces(client, subject, "viewer").to_a
+all_workspaces = list_workspaces(client, subject, "viewer", consistency: consistency).to_a
 ```
 
 See [`examples/list_workspaces.rb`](./examples/list_workspaces.rb) for a complete working example.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -62,7 +62,7 @@ KesselInventoryService::ClientBuilder.new(target)
 
 ## Streaming and Pagination
 
-- `list_workspaces(inventory, subject, relation, continuation_token = nil)` returns a lazy `Enumerator` that automatically paginates through `streamed_list_objects` responses with a page limit of 1000 (`DEFAULT_PAGE_LIMIT`). Iteration stops when there are no responses or the `continuation_token` becomes `nil`/falsey.
+- `list_workspaces(inventory, subject, relation, continuation_token = nil, consistency: nil)` returns a lazy `Enumerator` that automatically paginates through `streamed_list_objects` responses with a page limit of 1000 (`DEFAULT_PAGE_LIMIT`). When provided, the same `consistency` requirement is sent on every paginated request. Iteration stops when there are no responses or the `continuation_token` becomes `nil`/falsey.
 - For direct streaming calls, `streamed_list_objects` and `streamed_list_subjects` return server-streaming enumerables. Iterate with `.each` to process responses incrementally.
 
 ## Environment Configuration

--- a/examples/list_workspaces.rb
+++ b/examples/list_workspaces.rb
@@ -14,12 +14,15 @@ begin
 
   # Iterate one-by-one (lazy, constant memory)
   p "Listing workspaces"
-  list_workspaces(client, principal_subject("alice", "redhat"), "view_document").each do |response|
+  consistency = Kessel::Inventory::V1beta2::Consistency.new(minimize_latency: true)
+  list_workspaces(client, principal_subject("alice", "redhat"), "view_document",
+                  consistency: consistency).each do |response|
     p response
   end
 
   # Materialise all workspaces into an Array
-  all_workspaces = list_workspaces(client, principal_subject("alice", "redhat"), "view_document").to_a
+  all_workspaces = list_workspaces(client, principal_subject("alice", "redhat"), "view_document",
+                                   consistency: consistency).to_a
   p "Total workspaces: #{all_workspaces.length}"
 rescue Exception => e
   p 'Error occurred while listing workspaces'

--- a/lib/kessel/rbac/v2.rb
+++ b/lib/kessel/rbac/v2.rb
@@ -32,17 +32,20 @@ module Kessel
       # @param subject [SubjectReference] the subject to check permissions for
       # @param relation [String] the relationship type (e.g. "member", "admin", "viewer")
       # @param continuation_token [String, nil] optional token to resume listing
+      # @param consistency [Consistency, nil] optional consistency requirements for each request
       # @return [Enumerator] a lazy enumerator of +StreamedListObjectsResponse+ objects
       #
       # @example Lazy iteration (constant memory)
-      #   list_workspaces(inventory, subject, "viewer").each do |response|
+      #   consistency = Kessel::Inventory::V1beta2::Consistency.new(minimize_latency: true)
+      #   list_workspaces(inventory, subject, "viewer", consistency: consistency).each do |response|
       #     puts response.object.resource_id
       #   end
       #
       # @example Materialise into an Array (eager, all results in memory)
-      #   all_workspaces = list_workspaces(inventory, subject, "viewer").to_a
+      #   consistency = Kessel::Inventory::V1beta2::Consistency.new(minimize_latency: true)
+      #   all_workspaces = list_workspaces(inventory, subject, "viewer", consistency: consistency).to_a
       #
-      def list_workspaces(inventory, subject, relation, continuation_token = nil)
+      def list_workspaces(inventory, subject, relation, continuation_token = nil, consistency: nil)
         Enumerator.new do |yielder|
           loop do
             request = StreamedListObjectsRequest.new(
@@ -52,7 +55,8 @@ module Kessel
               pagination: RequestPagination.new(
                 limit: DEFAULT_PAGE_LIMIT,
                 continuation_token: continuation_token
-              )
+              ),
+              consistency: consistency
             )
 
             has_responses = false

--- a/sig/kessel/rbac.rbs
+++ b/sig/kessel/rbac.rbs
@@ -39,7 +39,7 @@ module Kessel
       def subject: (Kessel::Inventory::V1beta2::ResourceReference resource_ref, ?String? relation) -> Kessel::Inventory::V1beta2::SubjectReference
 
       # Lists all workspaces, allowing to resume with a continuation_token and optional consistency token
-      def list_workspaces: (untyped inventory, Kessel::Inventory::V1beta2::SubjectReference subject, String relation, ?String? continuation_token, ?consistency: untyped?) -> Enumerator[untyped, void]
+      def list_workspaces: (untyped inventory, Kessel::Inventory::V1beta2::SubjectReference subject, String relation, ?String? continuation_token, ?consistency: Kessel::Inventory::V1beta2::Consistency?) -> Enumerator[untyped, void]
     end
   end
 end

--- a/sig/kessel/rbac.rbs
+++ b/sig/kessel/rbac.rbs
@@ -38,8 +38,8 @@ module Kessel
       # Creates a subject reference
       def subject: (Kessel::Inventory::V1beta2::ResourceReference resource_ref, ?String? relation) -> Kessel::Inventory::V1beta2::SubjectReference
 
-      # Lists all workspaces, allowing to resume with a continuation_token
-      def list_workspaces: (untyped inventory, Kessel::Inventory::V1beta2::SubjectReference subject, String relation, ?String? continuation_token) -> Enumerator[untyped, void]
+      # Lists all workspaces, allowing to resume with a continuation_token and optional consistency token
+      def list_workspaces: (untyped inventory, Kessel::Inventory::V1beta2::SubjectReference subject, String relation, ?String? continuation_token, ?consistency: untyped?) -> Enumerator[untyped, void]
     end
   end
 end

--- a/spec/kessel/rbac/v2_spec.rb
+++ b/spec/kessel/rbac/v2_spec.rb
@@ -403,5 +403,47 @@ RSpec.describe Kessel::RBAC::V2 do
         expect(call_count).to eq(1)
       end
     end
+
+    context 'when consistency is provided' do
+      let(:consistency) { Kessel::Inventory::V1beta2::Consistency.new(minimize_latency: true) }
+
+      it 'passes consistency to each request' do
+        allow(mock_inventory).to receive(:streamed_list_objects) do |request|
+          expect(request.consistency).to eq(consistency)
+          [mock_response3]
+        end
+
+        list_workspaces(mock_inventory, mock_subject, relation, consistency: consistency).to_a
+      end
+
+      it 'preserves consistency across paginated requests' do
+        call_count = 0
+        allow(mock_inventory).to receive(:streamed_list_objects) do |request|
+          call_count += 1
+          expect(request.consistency).to eq(consistency)
+          case call_count
+          when 1
+            [mock_response1, mock_response2]
+          when 2
+            [mock_response3]
+          end
+        end
+
+        list_workspaces(mock_inventory, mock_subject, relation, consistency: consistency).to_a
+
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context 'when consistency is nil (default)' do
+      it 'does not set consistency on the request' do
+        allow(mock_inventory).to receive(:streamed_list_objects) do |request|
+          expect(request.consistency).to be_nil
+          [mock_response3]
+        end
+
+        list_workspaces(mock_inventory, mock_subject, relation).to_a
+      end
+    end
   end
 end


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-48470

## Summary
- add an optional `consistency:` keyword argument to `list_workspaces`
- pass the same consistency requirement through each paginated `streamed_list_objects` request
- cover provided and default-nil consistency behavior in `spec/kessel/rbac/v2_spec.rb`
- update the README, integration guide, and example script to show the new usage

## Testing
- [x] `bundle exec rspec spec/kessel/rbac/v2_spec.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `list_workspaces` now accepts an optional `consistency:` option (including for lazy, auto-paginating iteration), letting you control consistency behavior and tune for lower latency.
  * When provided, the consistency setting is applied to every paginated request.

* **Documentation**
  * Updated the API integration guidance and example code to demonstrate using `consistency:` for both streaming and materializing results.

* **Tests**
  * Added coverage to verify `consistency:` is preserved across pages and remains unset when omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->