### PR TITLE
Release v1.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kessel-sdk (1.9.1)
+    kessel-sdk (1.10.0)
       grpc (>= 1.73.0)
 
 GEM

--- a/lib/kessel/version.rb
+++ b/lib/kessel/version.rb
@@ -2,6 +2,6 @@
 
 module Kessel
   module Inventory
-    VERSION = '1.9.1'
+    VERSION = '1.10.0'
   end
 end


### PR DESCRIPTION
## Summary
- Bump version to 1.10.0
- Includes consistency token support for `list_workspaces()` and pagination documentation updates (merged since v1.9.1)
- Protobuf regeneration deferred to a separate release

## Test plan
- [x] `bundle exec rspec` — 133 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] `rake install_local` — gem builds and installs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.10.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->