### PR TITLE
Release v1.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kessel-sdk (1.10.0)
+    kessel-sdk (1.11.0)
       grpc (>= 1.73.0)
 
 GEM

--- a/lib/kessel/version.rb
+++ b/lib/kessel/version.rb
@@ -2,6 +2,6 @@
 
 module Kessel
   module Inventory
-    VERSION = '1.10.0'
+    VERSION = '1.11.0'
   end
 end


### PR DESCRIPTION
## Summary
- Bump `kessel-sdk` version from 1.10.0 to 1.11.0 (minor)
- Sync `Gemfile.lock` PATH gem version

Notable changes since v1.10.0 already on main: RBAC workspace fetches send `with_ancestry=true`, protobuf regen, dependency bumps.

## Test plan
- [x] `bundle exec rspec` — 136 examples, 0 failures
- [x] `bundle exec rubocop --parallel` — clean
- [x] Local gem build/install of `kessel-sdk-1.11.0`
- [ ] After merge: publish to RubyGems, tag `v1.11.0`, create GitHub release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->